### PR TITLE
Remove "push" classe from example uses in the comment

### DIFF
--- a/griddle.scss
+++ b/griddle.scss
@@ -9,7 +9,7 @@
  *     <div class="grid__cell unit-1-2"></div>
  *     <div class="grid__cell unit-1-2"></div>
  *     <div class="grid__cell unit-1-3"></div>
- *     <div class="grid__cell unit-1-3 before-1-3"></div>
+ *     <div class="grid__cell unit-1-3"></div>
  * </div>
  *
  * <div class="grid grid--center">


### PR DESCRIPTION
It's not very important, but you left a "push" classe (`before-1-3`) in the example uses.

Thanks a lot for your work.
