### PR TITLE
Fix comment which describes `griddle-build` mixin

### DIFF
--- a/griddle-build.scss
+++ b/griddle-build.scss
@@ -16,7 +16,7 @@
     @else { @return $list == $value; }
 }
 
-// Fluid grid units & offsets
+// Fluid grid units
 
 // USAGE: provide a space-separated list of integers, each of which represents
 // the number of parts that make up a grid component. Optionally provide a


### PR DESCRIPTION
Hi Nicolas,
`griddle-build` mixin does not generate offsets anymore. It's better not to leave it in comment.
