### PR TITLE
Complete the modifiers on container and units of the grid

### DIFF
--- a/griddle.scss
+++ b/griddle.scss
@@ -102,7 +102,7 @@ $grid-gutter: 20px !default; // can be px, em, or %
  */
 
 .grid--left {
-  text-align: left;
+    text-align: left;
 }
 
 /**
@@ -112,7 +112,7 @@ $grid-gutter: 20px !default; // can be px, em, or %
  */
 
 .grid--right {
-  text-align: right;
+    text-align: right;
 }
 
 /**
@@ -130,9 +130,10 @@ $grid-gutter: 20px !default; // can be px, em, or %
  * Set a specific unit to be horizontally on the left. Doesn't affect
  * any other units. Can still contain a child `grid` object.
  */
+
 .grid__cell--left {
-  display: block;
-  margin: 0 auto 0 0;
+    display: block;
+    margin: 0 auto 0 0;
 }
 
 /**
@@ -140,9 +141,10 @@ $grid-gutter: 20px !default; // can be px, em, or %
  * Set a specific unit to be horizontally on the right. Doesn't affect
  * any other units. Can still contain a child `grid` object.
  */
+
 .grid__cell--right {
-  display: block;
-  margin: 0 0 0 auto;
+    display: block;
+    margin: 0 0 0 auto;
 }
 
 /**


### PR DESCRIPTION
Hi Nicolas,
Currently, griddle allows us to define the alignment of the grid and the text in the units thanks to the same variable: `$grid-direction`.

However, no modifier can reverse that. We can center one or more units but we can't pull it/them on the right or on the left according to the cases.
I therefore propose to complete the modifiers to do that like `grid--center` or `grid__cell--center`.

We may use:
- `grid--right` and `grid__cell--right` when grid direction is set to the left.
- `grid--left` and `grid__cell--left` when grid direction is set to the right.

It is not a big feature, but this can prove to be useful in some cases.
I put online some test cases to get a result idea more easily: [see there](http://7studio.fr/github/griddle/feat-direction-modifiers/).

I hope you will find this pull request interesting,
Xavier.
