### PR TITLE
Fix missing semicolon in `gcf` function

### DIFF
--- a/_griddle-build.scss
+++ b/_griddle-build.scss
@@ -6,7 +6,7 @@
 
 @function gcf($a, $b) {
     @if $b == 0 { @return $a; }
-    @else { @return gcf($b, $a % $b) }
+    @else { @return gcf($b, $a % $b); }
 }
 
 // Check if a list contains a value


### PR DESCRIPTION
This issue is really minor.
Adding this semicolon does not fix any compilation issue but why the first line has one whereas the second one does not.
It's just to have a similar code and convention everywhere.

In fact (for your information), it also fixes an incorrect syntax highlighting from [SCSS.tmbundle](https://github.com/MarioRicalde/SCSS.tmbundle) in Sublime Text.
It's really unpleasant to see it every time (There is a screenshot of what I see: [subl-scss-tmbundle-issue.jpg](http://7studio.fr/github/griddle/fix-gcf-semicolon/subl-scss-tmbundle-issue.jpg)).
Currently, I don't find any issue about it and I intent to open a new issue to indicate this error.

Xavier.
